### PR TITLE
enable datashare procs to be callable by other projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ logs/
 .env
 .DS_Store
 .user.yml
+
+dbt-env


### PR DESCRIPTION
- Add special case rule for UTILS db to look at `_create_udfs` instead of `_create_gold`
- Add database identifier to proc calls instead of inferring from the existing context
- Always call procedure as owner (ACCOUNTADMIN) in production environment
  - This will allow other roles w/ usage perms to be able to execute the procs successfully