### PR TITLE
remove project name pre-processing

### DIFF
--- a/macros/streamline/create_api_integration.sql
+++ b/macros/streamline/create_api_integration.sql
@@ -1,12 +1,12 @@
 {% macro create_api_integration(project_name, snowflake_role_arn, endpoint_urls) %}
-  {% set integration_name = "aws_" ~ project_name ~ "_api" %}
+  
   {% set allowed_prefixes = [] %}
   {% for url in endpoint_urls %}
     {% do allowed_prefixes.append("'" ~ url ~ "'") %}
   {% endfor %}
   {% set allowed_prefixes = allowed_prefixes|join(", ") %}
   {% set sql %}
-    CREATE OR REPLACE API INTEGRATION {{ integration_name }}
+    CREATE OR REPLACE API INTEGRATION {{ project_name }}
     API_PROVIDER = aws_api_gateway 
     API_AWS_ROLE_ARN = '{{ snowflake_role_arn }}' 
     API_ALLOWED_PREFIXES = ({{ allowed_prefixes }})


### PR DESCRIPTION
- Removes pre-processing of `project-name` as this is already predetermined and set accordingly to the environment (`prod/stg`) from the cloud-formation template 